### PR TITLE
theading: Fix segfault in onCleanup

### DIFF
--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -210,6 +210,8 @@ void Threading::doCleanup() {
     logMessageWithTime("Threading::doCleanup");
     __itt_task_begin(domain, __itt_null, __itt_null, threading_doCleanup);
 
+    std::vector<mariadb::account_ref> empty_accounts;
+
     //Will only be called from mainthread so noone can insert stuff now.
     for (auto& [acc,workerlist] : workers) {
 
@@ -242,7 +244,10 @@ void Threading::doCleanup() {
             }
         }
         if (workerlist.empty())
-            workers.erase(acc);
+            empty_accounts.push_back(acc);
+    }
+    for (mariadb::account_ref& acc : empty_accounts) {
+        workers.erase(acc);
     }
     lastCleanup = std::chrono::system_clock::now();
     __itt_task_end(domain);


### PR DESCRIPTION
On some platforms, deleting elements from std::map::iterator while iterating through it can cause a segfault.

The reason being that calling erase() invalidates the iterator(s). This was observed to cause a problem when running intercept code on Windows 10 Server.

Despite this (apparently) not being an issue due to implementation details with g++ 11 and the  MSVC runtimes on Win10 Home/Pro, this was a usage of undefined behavior, and removing it resolves the issue we observed on Win10 server. 