### PR TITLE
add support for relative config.yaml path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ add_subdirectory(yaml-cpp)
 
 SET(CC_PLUGIN_DEFAULT "STATIC" CACHE STRING "want static" FORCE)
 
+
+SET(INSTALL_PLUGINDIR "${CMAKE_CURRENT_BINARY_DIR}/mariadb-connector-c") 
 add_subdirectory(mariadb-connector-c)
 
 CONFIGURE_FILE("${CMAKE_CURRENT_BINARY_DIR}/mariadb-connector-c/include/mariadb_version.h"

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,7 @@ public:
 class Config : public intercept::singleton<Config> {
     
 public:
+    std::filesystem::path GetCurrentDLLPath();
     void reloadConfig();
 
     ConfigStatement getStatement(r_string name) {

--- a/src/logger.h
+++ b/src/logger.h
@@ -40,6 +40,7 @@ public:
 private:
     void pushTimestamp(std::ostream& str) const;
     void refreshLogfiles();
+    void deleteOldLogs(int days);
 
     std::mutex queryLog_lock;
     bool queryLogEnabled = false;


### PR DESCRIPTION
Added support for a relative config.yaml file in relation to the intercept-database_x64.dll. Now, you can rename the @InterceptDB folder, and the config.yaml file will still be loaded.